### PR TITLE
fix: pin certifi version in dockerfile.cpu instead of requirement.txt

### DIFF
--- a/pytorch/jobs/docker/2.0/py3/Dockerfile.gpu
+++ b/pytorch/jobs/docker/2.0/py3/Dockerfile.gpu
@@ -69,7 +69,6 @@ RUN ln -s $(which ${PYTHON}) /usr/local/bin/python \
 
 RUN apt-get update && apt-get -y install cmake protobuf-compiler
 
-
 # Installing our custom python libraries
 RUN ${PIP} install --no-cache --upgrade \
         amazon-braket-default-simulator==1.20.0 \
@@ -98,6 +97,11 @@ RUN ${PIP} install --no-cache --upgrade \
         six==1.16.0 \
         scipy==1.9.3 \
         typing_extensions==4.3.0
+
+# Ensure below libraries are updated to mitigate vulnerability
+RUN ${PIP} install --no-cache --upgrade \
+# https://nvd.nist.gov/vuln/detail/CVE-2023-37920
+        certifi>=2023.7.22  
 
 RUN ${PIP} install --no-cache --upgrade sagemaker-training==4.4.10
 

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,6 +1,5 @@
 wheel==0.38.1
 docker==6.0.1
-certifi>=2023.7.22
 fabric==2.5.0
 invoke==1.6.0
 pyfiglet==0.8.post1

--- a/tensorflow/jobs/docker/2.12/py3/Dockerfile.gpu
+++ b/tensorflow/jobs/docker/2.12/py3/Dockerfile.gpu
@@ -12,12 +12,6 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/* \
  && apt-get clean
 
-# Ensure below libraries are updated to mitigate vulnerability
-RUN apt-get update \
- && apt-get install -y --no-install-recommends \
-    openssh-client \
-    vim
-
 # Ensure below libraries are pinned to mitigate vulnerability
 RUN ${PIP} install --no-cache --upgrade \
         certifi>=2023.7.22  

--- a/tensorflow/jobs/docker/2.12/py3/Dockerfile.gpu
+++ b/tensorflow/jobs/docker/2.12/py3/Dockerfile.gpu
@@ -12,6 +12,16 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/* \
  && apt-get clean
 
+# Ensure below libraries are updated to mitigate vulnerability
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+    openssh-client \
+    vim
+
+# Ensure below libraries are pinned to mitigate vulnerability
+RUN ${PIP} install --no-cache --upgrade \
+        certifi>=2023.7.22  
+    
 # Installing our custom python libraries
 RUN ${PIP} install --no-cache --upgrade \
         amazon-braket-default-simulator==1.20.0 \
@@ -38,7 +48,8 @@ RUN ${PIP} install --no-cache --upgrade \
         scikit-learn==1.2.2 \
         six==1.16.0 \
         scipy==1.9.3 \
-        typing_extensions==4.3.0
+        typing_extensions==4.3.0 \
+        certifi==2023.7.22
 
 RUN ${PIP} install --no-cache --upgrade sagemaker-training==4.4.10
 

--- a/tensorflow/jobs/docker/2.12/py3/Dockerfile.gpu
+++ b/tensorflow/jobs/docker/2.12/py3/Dockerfile.gpu
@@ -14,6 +14,7 @@ RUN apt-get update \
 
 # Ensure below libraries are pinned to mitigate vulnerability
 RUN ${PIP} install --no-cache --upgrade \
+# https://nvd.nist.gov/vuln/detail/CVE-2023-37920
         certifi>=2023.7.22  
     
 # Installing our custom python libraries
@@ -42,8 +43,7 @@ RUN ${PIP} install --no-cache --upgrade \
         scikit-learn==1.2.2 \
         six==1.16.0 \
         scipy==1.9.3 \
-        typing_extensions==4.3.0 \
-        certifi==2023.7.22
+        typing_extensions==4.3.0
 
 RUN ${PIP} install --no-cache --upgrade sagemaker-training==4.4.10
 


### PR DESCRIPTION

*Description of changes:*
Update certifi to 2023.7.22

*Testing done:*
Tested certifi version with locally built pytorch container
![image](https://github.com/amazon-braket/amazon-braket-containers/assets/23483181/a4242b5a-ef09-41df-a543-c963458a6f9c)

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-containers/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-containers/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-containers/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-containers/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
