### PR TITLE
feat: install qiskit-braket-provider==0.0.4 on base image

### DIFF
--- a/base/jobs/docker/1.0/py3/Dockerfile.cpu
+++ b/base/jobs/docker/1.0/py3/Dockerfile.cpu
@@ -121,8 +121,9 @@ RUN ${PIP} install --no-cache --upgrade \
         PennyLane-Lightning==0.31.0 \
         scikit-learn==1.2.2 \
         requests==2.26.0 \
-        scipy==1.9.3
-
+        scipy==1.9.3 \
+        qiskit-braket-provider==0.0.4
+        
 RUN ${PIP} install --no-cache --upgrade sagemaker-training==4.4.10
 
 RUN HOME_DIR=/root \


### PR DESCRIPTION
*Description of changes:*
Enable qiskit-braket-provider==0.0.4 to be installed to base container by default 

*Testing done:*
After building the code change, the library was able to get imported successfully in python shell.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-containers/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-containers/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-containers/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-containers/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
