### PR TITLE
Update PennyLane Plugin Version

### DIFF
--- a/base/jobs/docker/1.0/py3/requirements.txt
+++ b/base/jobs/docker/1.0/py3/requirements.txt
@@ -1,6 +1,6 @@
 amazon-braket-default-simulator==1.20.1
 amazon-braket-schemas==1.19.1
-amazon-braket-pennylane-plugin==1.21.0
+amazon-braket-pennylane-plugin==1.23.0
 amazon-braket-sdk==1.59.1
 awscli==1.29.53
 botocore==1.31.53


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
PL-Plugin version 1.23 solves some conflicts with newer PL version > 0.33 due to `active_return`. Can we update the plugin version in the base container?
```
ImportError: cannot import name 'active_return' from 'pennylane' (/usr/local/lib/python3.10/site-packages/pennylane/__init__.py)
```

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-containers/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-containers/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-containers/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-containers/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
