### PR TITLE
infra: change dependabot to have grouped updates for directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,6 @@
 
 version: 2
 updates:
-
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -13,7 +12,11 @@ updates:
 
   - package-ecosystem: "pip"
     # Files stored in repository root
-    directory: "/"
+    directories: 
+      - "/"
+      - "/pytorch/jobs/docker/2.2/py3/"
+      - "/base/jobs/docker/1.0/py3"
+      - "/tensorflow/jobs/docker/2.14/py3/"
     schedule:
       interval: "weekly"
     commit-message:
@@ -27,55 +30,3 @@ updates:
           patterns:
             - "*"       # A wildcard that matches all dependencies in the package
                         # ecosystem. Note: using "*" may open a large pull request
-
-  - package-ecosystem: "pip"
-    # Files stored in repository for the base image
-    directory: "/base/jobs/docker/1.0/py3"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: infra
-    groups:
-       # Specify a name for the group, which will be used in pull request titles
-       # and branch names
-       dev-dependencies:
-          # Define patterns to include dependencies in the group (based on
-          # dependency name)
-          patterns:
-            - "*"       # A wildcard that matches all dependencies in the package
-                        # ecosystem. Note: using "*" may open a large pull request
-
-  - package-ecosystem: "pip"
-    # Files stored in repository for the tensorflow image
-    directory: "/tensorflow/jobs/docker/2.14/py3/"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: infra
-    groups:
-       # Specify a name for the group, which will be used in pull request titles
-       # and branch names
-       dev-dependencies:
-          # Define patterns to include dependencies in the group (based on
-          # dependency name)
-          patterns:
-            - "*"       # A wildcard that matches all dependencies in the package
-                        # ecosystem. Note: using "*" may open a large pull request
-
-  - package-ecosystem: "pip"
-    # Files stored in repository for the pytorch image
-    directory: "/pytorch/jobs/docker/2.2/py3/"
-    schedule:
-      interval: "weekly"
-    commit-message:
-      prefix: infra
-    groups:
-       # Specify a name for the group, which will be used in pull request titles
-       # and branch names
-       dev-dependencies:
-          # Define patterns to include dependencies in the group (based on
-          # dependency name)
-          patterns:
-            - "*"       # A wildcard that matches all dependencies in the package
-                        # ecosystem. Note: using "*" may open a large pull request
-


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
https://github.blog/changelog/2024-04-29-dependabot-multi-directory-configuration-public-beta-now-available/

We can now have dependabot cut a grouped PR instead of individual ones for the images.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-containers/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-containers/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-containers/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-containers/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
