### PR TITLE
infra: set a minimum sagemaker version to avoid cython build issues

### DIFF
--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -2,9 +2,9 @@ amazon-braket-schemas
 amazon-braket-sdk
 boto3==1.35.22
 certifi>=2023.7.22
-invoke==2.2.0
+invoke
 mock
 pennylane>=0.35.0
-pytest==8.3.3
+pytest
 pytest-xdist
 sagemaker

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -2,6 +2,7 @@ amazon-braket-schemas
 amazon-braket-sdk
 boto3==1.35.22
 certifi>=2023.7.22
+cython<3 # https://github.com/yaml/pyyaml/issues/736
 invoke
 mock
 pennylane>=0.35.0

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,11 +1,10 @@
 amazon-braket-schemas
 amazon-braket-sdk
-boto3==1.35.22
+boto3==1.35.43
 certifi>=2023.7.22
-cython<3 # https://github.com/yaml/pyyaml/issues/736
 invoke
 mock
 pennylane>=0.35.0
 pytest
 pytest-xdist
-sagemaker
+sagemaker>=2.232.2


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
`PyYaml` < 6 is broken due to the `cython` upgrade to 3.x. Therefore, we constrain `sagemaker` to the version that uses `PyYaml~=6` to avoid the cython build issues.

https://github.com/yaml/pyyaml/issues/736

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ ] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-containers/blob/main/CONTRIBUTING.md) doc
- [ ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-containers/blob/main/CONTRIBUTING.md#commit-your-change)
- [ ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-containers/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-containers/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
