### PR TITLE
fix: invoke train command in SageMaker tests

### DIFF
--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -58,7 +58,6 @@ runs:
       run: |
         pytest test/braket_tests/${{ inputs.container-type }} -vv --role GitHubIntegTestBuildRole --from-build-results ${{ env.BUILD_RESULTS_PATH }} --use-local-jobs True --use-local-sim True
       shell: bash
-    # Exercises the image's default command, which the Braket tests do not.
     - name: Run SageMaker Tests
       run: |
         pip install -r test/requirements-sagemaker.txt

--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -58,6 +58,12 @@ runs:
       run: |
         pytest test/braket_tests/${{ inputs.container-type }} -vv --role GitHubIntegTestBuildRole --from-build-results ${{ env.BUILD_RESULTS_PATH }} --use-local-jobs True --use-local-sim True
       shell: bash
+    # Exercises the image's default command, which the Braket tests do not.
+    - name: Run SageMaker Tests
+      run: |
+        pip install -r test/requirements-sagemaker.txt
+        pytest test/sagemaker_tests -vv --role GitHubIntegTestBuildRole --s3-bucket ${{ env.AMZN_BRAKET_OUT_S3_BUCKET }} --s3-location ${{ inputs.container-type }} --from-build-results ${{ env.BUILD_RESULTS_PATH }}
+      shell: bash
     - name: Update prebuild tag
       run: |
         python src/tag_image.py --build ${{ env.BUILD_RESULTS_PATH }} --tag ${{ inputs.container-type }}_prebuild_tag

--- a/.github/actions/build-container/action.yml
+++ b/.github/actions/build-container/action.yml
@@ -58,11 +58,6 @@ runs:
       run: |
         pytest test/braket_tests/${{ inputs.container-type }} -vv --role GitHubIntegTestBuildRole --from-build-results ${{ env.BUILD_RESULTS_PATH }} --use-local-jobs True --use-local-sim True
       shell: bash
-    - name: Run SageMaker Tests
-      run: |
-        pip install -r test/requirements-sagemaker.txt
-        pytest test/sagemaker_tests -vv --role GitHubIntegTestBuildRole --s3-bucket ${{ env.AMZN_BRAKET_OUT_S3_BUCKET }} --s3-location ${{ inputs.container-type }} --from-build-results ${{ env.BUILD_RESULTS_PATH }}
-      shell: bash
     - name: Update prebuild tag
       run: |
         python src/tag_image.py --build ${{ env.BUILD_RESULTS_PATH }} --tag ${{ inputs.container-type }}_prebuild_tag

--- a/test/sagemaker_tests/test_basics.py
+++ b/test/sagemaker_tests/test_basics.py
@@ -13,6 +13,7 @@
 
 import io
 import os
+import subprocess
 from contextlib import redirect_stdout
 
 import boto3
@@ -23,6 +24,7 @@ from sagemaker.train.model_trainer import Mode
 MODULE_NAME = "run_script"
 SCRIPT_NAME = MODULE_NAME + ".py"
 SCRIPT_PATH = "./test/resources/"
+CONTAINER_COMMAND = "train"
 
 
 def test_basics(account, region, role, s3_bucket, s3_location, image_list):
@@ -39,6 +41,22 @@ def upload_test_script_to_s3(s3_bucket, s3_location):
     s3_client.upload_file(SCRIPT_PATH + SCRIPT_NAME, s3_bucket, f"{s3_location}/{SCRIPT_NAME}")
 
 
+def tag_image_with_default_command(image_path):
+    """Returns a local tag for image_path whose only difference is a default command.
+
+    The job images carry no command of their own and rely on the caller to run
+    ``train``, which SageMaker managed training passes but ModelTrainer local
+    container mode does not.
+    """
+    local_tag = f"{image_path.rsplit('/', 1)[-1].replace(':', '-')}-default-command"
+    subprocess.run(
+        ["docker", "build", "--quiet", "--tag", local_tag, "-"],
+        input=f'FROM {image_path}\nCMD ["{CONTAINER_COMMAND}"]\n'.encode(),
+        check=True,
+    )
+    return local_tag
+
+
 def single_image_test(account, role, s3_bucket, s3_location, image_path):
     environment_variables = {
         "AMZN_BRAKET_SCRIPT_S3_URI": f"s3://{s3_bucket}/{s3_location}/{SCRIPT_NAME}",
@@ -46,7 +64,7 @@ def single_image_test(account, role, s3_bucket, s3_location, image_path):
     }
     trainer = ModelTrainer(
         training_mode=Mode.LOCAL_CONTAINER,
-        training_image=image_path,
+        training_image=tag_image_with_default_command(image_path),
         role=f"arn:aws:iam::{account}:role/{role}",
         compute=Compute(instance_count=1, instance_type="local"),
         hyperparameters=environment_variables,

--- a/test/sagemaker_tests/test_basics.py
+++ b/test/sagemaker_tests/test_basics.py
@@ -42,12 +42,7 @@ def upload_test_script_to_s3(s3_bucket, s3_location):
 
 
 def tag_image_with_default_command(image_path):
-    """Returns a local tag for image_path whose only difference is a default command.
-
-    The job images carry no command of their own and rely on the caller to run
-    ``train``, which SageMaker managed training passes but ModelTrainer local
-    container mode does not.
-    """
+    """Required for the tests to work with ModelTrainer local container mode."""
     local_tag = f"{image_path.rsplit('/', 1)[-1].replace(':', '-')}-default-command"
     subprocess.run(
         ["docker", "build", "--quiet", "--tag", local_tag, "-"],

--- a/test/sagemaker_tests/test_basics.py
+++ b/test/sagemaker_tests/test_basics.py
@@ -33,7 +33,7 @@ def test_basics(account, region, role, s3_bucket, s3_location, image_list):
               f" --password-stdin {account}.dkr.ecr.{region}.amazonaws.com")
     upload_test_script_to_s3(s3_bucket, s3_location)
     for image_path in image_list:
-        single_image_test(account, role, s3_bucket, s3_location, image_path)
+        single_image_test(account, region, role, s3_bucket, s3_location, image_path)
 
 
 def upload_test_script_to_s3(s3_bucket, s3_location):
@@ -52,8 +52,23 @@ def tag_image_with_default_command(image_path):
     return local_tag
 
 
-def single_image_test(account, role, s3_bucket, s3_location, image_path):
-    environment_variables = {
+def container_credentials(region):
+    credentials = boto3.Session().get_credentials()
+    assert credentials is not None, "No AWS credentials found to pass to the container"
+    frozen_credentials = credentials.get_frozen_credentials()
+    environment = {
+        "AWS_REGION": region,
+        "AWS_DEFAULT_REGION": region,
+        "AWS_ACCESS_KEY_ID": frozen_credentials.access_key,
+        "AWS_SECRET_ACCESS_KEY": frozen_credentials.secret_key,
+    }
+    if frozen_credentials.token:
+        environment["AWS_SESSION_TOKEN"] = frozen_credentials.token
+    return environment
+
+
+def single_image_test(account, region, role, s3_bucket, s3_location, image_path):
+    hyperparameters = {
         "AMZN_BRAKET_SCRIPT_S3_URI": f"s3://{s3_bucket}/{s3_location}/{SCRIPT_NAME}",
         "AMZN_BRAKET_SCRIPT_ENTRY_POINT": f"{MODULE_NAME}",
     }
@@ -62,8 +77,8 @@ def single_image_test(account, role, s3_bucket, s3_location, image_path):
         training_image=tag_image_with_default_command(image_path),
         role=f"arn:aws:iam::{account}:role/{role}",
         compute=Compute(instance_count=1, instance_type="local"),
-        hyperparameters=environment_variables,
-        environment=environment_variables,
+        hyperparameters=hyperparameters,
+        environment={**hyperparameters, **container_credentials(region)},
     )
     trainer_output = io.StringIO()
     with redirect_stdout(trainer_output):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Follow-up to #488 which upgraded the SageMaker libraries used in the tests. This PR adjusts the tests to properly pass through AWS credentials and invoke the train command to be compatible with the new library versions.

*Testing done:*
Verified tests pass locally.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-containers/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-containers/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-containers/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-containers/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
